### PR TITLE
Update cookies and lazyloading

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import ProtectedRoutes from "./pages/ProtectedRoute";
 import store from "./store/store";
 import { refreshAccessToken } from "./store/authSlice";
 import { useEffect } from "react";
+import { getCookie } from "./shared/util/cookiesUtils";
 
 const router = createBrowserRouter([
   {
@@ -48,7 +49,12 @@ const router = createBrowserRouter([
 
 function App() {
   // init login state by refreshAccessToken in case serverside cookies available
-  useEffect(() =>  {store.dispatch(refreshAccessToken())}, []);
+  useEffect(() =>  {
+    const IsRefreshTokenAvailable = getCookie("IsRefreshTokenAvailable");
+    if (IsRefreshTokenAvailable) {
+      store.dispatch(refreshAccessToken())
+    }
+  }, []);
 
   return <RouterProvider router={router} />;
 }

--- a/frontend/src/components/UI/IsotopeGallery.tsx
+++ b/frontend/src/components/UI/IsotopeGallery.tsx
@@ -220,7 +220,7 @@ const IsotopeGallery = forwardRef((props: IsotopeGalleryProps, ref) => {
                 src={imgItem.srcPreview ? imgItem.srcPreview : imgItem.src}
                 alt={imgItem.alt}
                 effect="blur"
-                afterLoad={afterLoad}
+                onLoad={afterLoad}
                 beforeLoad={beforeLoad}
                 visibleByDefault={!lazyLoading}
               />

--- a/frontend/src/components/contents/Gallery/GalleryBody.tsx
+++ b/frontend/src/components/contents/Gallery/GalleryBody.tsx
@@ -61,7 +61,7 @@ const GalleryBody = (props: GalleryBodyProps) => {
           containerName="photoList"
           onImgClick={props.onImgClick}
           onAllImgLoaded={() => setImgAllLoaded(true)}
-          lazyLoading={true}
+          lazyLoading={false}
         />
       </div>
     </div>

--- a/frontend/src/components/contents/Home/IsotopeItems.tsx
+++ b/frontend/src/components/contents/Home/IsotopeItems.tsx
@@ -16,6 +16,7 @@ interface IsotopeItemsProps {
   divRef: React.RefObject<HTMLDivElement>;
   onImgClick: (imgIndex: number) => void;
   onImgLoaded: () => void;
+  lazyLoading?: boolean;
 }
 
 export interface IsotopRefFunction {
@@ -86,7 +87,7 @@ const IsotopeItems = forwardRef((props: IsotopeItemsProps, ref) => {
             setImgAllLoaded(true);
             props.onImgLoaded();
           }}
-          lazyLoading={true}
+          lazyLoading={props.lazyLoading}
         />
       </div>
     </div>

--- a/frontend/src/components/contents/Home/MapGallery.tsx
+++ b/frontend/src/components/contents/Home/MapGallery.tsx
@@ -48,6 +48,7 @@ const MapGallery = (props: { imageList: GalleryItem[] }) => {
           imageList={props.imageList}
           onImgClick={onImgClick}
           onImgLoaded={() => setImgAllLoaded(true)}
+          lazyLoading={false}
         />
         <LightboxComponent
           imageList={props.imageList as LightboxGalleryItem[]}

--- a/frontend/src/pages/ProtectedRoute.tsx
+++ b/frontend/src/pages/ProtectedRoute.tsx
@@ -10,11 +10,15 @@ import {
 } from "../store/authSlice";
 import { useAppDispatch } from "../store/store";
 import LoadingFullPage from "../components/UI/LoadingFullPage";
+import { getCookie } from "../shared/util/cookiesUtils";
 
 const ProtectedRoutes = () => {
   const dispatch = useAppDispatch();
   useEffect(() => {
-    dispatch(refreshAccessToken());
+    const IsRefreshTokenAvailable = getCookie("IsRefreshTokenAvailable");
+    if (IsRefreshTokenAvailable) {
+      dispatch(refreshAccessToken());
+    }
   }, [dispatch]);
 
   const location = useLocation();
@@ -22,15 +26,15 @@ const ProtectedRoutes = () => {
   const token = useSelector(stateAuthToken);
   const authProcessState = useSelector(stateAuthProcessState);
 
-  if (authProcessState === 'pending' || authProcessState === 'init' ) {
+  if (authProcessState === "pending" || authProcessState === "init") {
     throw Promise.resolve(); // Throw a promise to suspend rendering
   }
 
   return isAuth && token ? (
-      <Outlet />
-    ) : (
-      <Navigate to="/Error" replace state={{ from: location }} />
-    );
+    <Outlet />
+  ) : (
+    <Navigate to="/Error" replace state={{ from: location }} />
+  );
 };
 
 const ProtectedRoutesWrapper = () => {

--- a/frontend/src/shared/util/cookiesUtils.tsx
+++ b/frontend/src/shared/util/cookiesUtils.tsx
@@ -3,7 +3,7 @@ export function setCookie(name: string, value: string, expireIn: number): void {
     now.setTime(now.getTime() + expireIn);
 
     const expires = "expires=" + now.toUTCString();
-    document.cookie = `${name}=${value}; ${expires}; path=/`;
+    document.cookie = `${name}=${value}; SameSite=Strict; ${expires}; path=/`;
 }
 
 export function getCookie(cookieName: string): string | undefined {

--- a/frontend/src/shared/util/cookiesUtils.tsx
+++ b/frontend/src/shared/util/cookiesUtils.tsx
@@ -1,0 +1,25 @@
+export function setCookie(name: string, value: string, expireIn: number): void {
+    const now = new Date();
+    now.setTime(now.getTime() + expireIn);
+
+    const expires = "expires=" + now.toUTCString();
+    document.cookie = `${name}=${value}; ${expires}; path=/`;
+}
+
+export function getCookie(cookieName: string): string | undefined {
+    const cookieKey = cookieName + "=";
+    const cookieArray = document.cookie.split(';');
+
+    for(let i = 0; i < cookieArray.length; i++) {
+        let cookie = cookieArray[i].trim();
+        if (cookie.startsWith(cookieKey)) {
+            return cookie.substring(cookieKey.length);
+        }
+    }
+
+    return undefined;
+}
+
+export function deleteCookie(name: string): void {
+    document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/';
+}

--- a/frontend/src/store/authSlice.tsx
+++ b/frontend/src/store/authSlice.tsx
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
+import { setCookie, deleteCookie } from "../shared/util/cookiesUtils";
 
 import { RootState } from "./store";
 
@@ -45,6 +46,8 @@ export const fetchLogin = createAsyncThunk<
       return error;
     });
   if (response.status === 200 || response.statusText === "OK") {
+    const expireDay = 7 * 24 * 60 * 60 * 1000; // 7 days
+    setCookie("IsRefreshTokenAvailable", "true", expireDay);
     return {
       user: loginData.username,
       token: response.data.access,
@@ -79,10 +82,13 @@ export const refreshAccessToken = createAsyncThunk<
     });
 
   if (response.status === 200 || response.statusText === "OK") {
+    const expireDay = 7 * 24 * 60 * 60 * 1000; // 7 days
+    setCookie("IsRefreshTokenAvailable", "true", expireDay);
     return {
       token: response.data.access,
     };
   } else {
+    deleteCookie("IsRefreshTokenAvailable");
     return rejectWithValue({
       errMsg: "Failed to refresh token. Token is expired or invalid",
     });
@@ -102,6 +108,7 @@ const authSlice = createSlice({
       state.user = null;
       state.token = null;
       state.isAuthenticated = false;
+      deleteCookie("IsRefreshTokenAvailable");
     },
   },
   extraReducers(builder) {


### PR DESCRIPTION
- Add `IsRefreshTokenAvailable` cookie to determine whether to request for refresh token
- Add option `lazyLoading` for Isotope
- Update to not using lazyloading on gallery to make sure Isotope filter selection works correctly